### PR TITLE
FIX:Update camera.py

### DIFF
--- a/visca/camera.py
+++ b/visca/camera.py
@@ -172,7 +172,7 @@ class D100(Camera):
         :return: Replaced string.
         :rtype: str
         """
-        rep = dict((re.escape(k), v) for k, v in rep.iteritems())
+        rep = {re.escape(k): v for k, v in rep.items()}
         pattern = re.compile("|".join(rep.keys()))
         return pattern.sub(lambda m: rep[re.escape(m.group(0))], text)
 


### PR DESCRIPTION
BUG: AttributeError: 'dict' object has no attribute 'iteritems'.

iteritems() has been removed in recent Python releases. Replace iteritems() to items()